### PR TITLE
Fix crash: request NameError

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 # Flask
-from flask import Flask
+from flask import Flask, request
 app = Flask(__name__)
 
 # Logging imports


### PR DESCRIPTION
Fixes this: : builtins.NameError  NameError: name 'request' is not defined